### PR TITLE
Allow building with mmorph-1.1.0 on GHC 8.0.1 and older

### DIFF
--- a/src/Ether/TaggedTrans.hs
+++ b/src/Ether/TaggedTrans.hs
@@ -7,7 +7,7 @@ import Control.Monad (MonadPlus)
 import Control.Monad.Fix (MonadFix)
 import Control.Monad.Trans.Class (MonadTrans, lift)
 import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Morph (MFunctor(..), MMonad)
+import Control.Monad.Morph (MFunctor(..), MMonad(..))
 import Control.Monad.Catch (MonadThrow, MonadCatch, MonadMask)
 
 import qualified Control.Monad.Base as MB
@@ -33,7 +33,7 @@ newtype TaggedTrans tag trans m a = TaggedTrans (trans m a)
   deriving
     ( Generic
     , Functor, Applicative, Alternative, Monad, MonadPlus
-    , MonadFix, MonadTrans, MonadIO, MMonad
+    , MonadFix, MonadTrans, MonadIO
     , MonadThrow, MonadCatch, MonadMask )
 
 type Pack tag trans m a = trans m a -> TaggedTrans tag trans m a
@@ -179,3 +179,10 @@ instance
 -- trigger GHC Trac #11837 on GHC 8.0.1 and older.
 instance MFunctor trans => MFunctor (TaggedTrans tag trans) where
     hoist f (TaggedTrans t) = TaggedTrans (hoist f t)
+
+-- NB: Don't use GeneralizedNewtypeDeriving to create this instance, as it will
+-- trigger GHC Trac #11837 on GHC 8.0.1 and older.
+instance MMonad trans => MMonad (TaggedTrans tag trans) where
+    embed f (TaggedTrans t) = TaggedTrans (embed (runTaggedTrans . f) t)
+      where
+        runTaggedTrans (TaggedTrans x) = x

--- a/src/Ether/TaggedTrans.hs
+++ b/src/Ether/TaggedTrans.hs
@@ -7,7 +7,7 @@ import Control.Monad (MonadPlus)
 import Control.Monad.Fix (MonadFix)
 import Control.Monad.Trans.Class (MonadTrans, lift)
 import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Morph (MFunctor, MMonad)
+import Control.Monad.Morph (MFunctor(..), MMonad)
 import Control.Monad.Catch (MonadThrow, MonadCatch, MonadMask)
 
 import qualified Control.Monad.Base as MB
@@ -33,7 +33,7 @@ newtype TaggedTrans tag trans m a = TaggedTrans (trans m a)
   deriving
     ( Generic
     , Functor, Applicative, Alternative, Monad, MonadPlus
-    , MonadFix, MonadTrans, MonadIO, MFunctor, MMonad
+    , MonadFix, MonadTrans, MonadIO, MMonad
     , MonadThrow, MonadCatch, MonadMask )
 
 type Pack tag trans m a = trans m a -> TaggedTrans tag trans m a
@@ -174,3 +174,8 @@ instance
   where
     throwError = lift . Mtl.throwError
     catchError = Lift.liftCatch Mtl.catchError
+
+-- NB: Don't use GeneralizedNewtypeDeriving to create this instance, as it will
+-- trigger GHC Trac #11837 on GHC 8.0.1 and older.
+instance MFunctor trans => MFunctor (TaggedTrans tag trans) where
+    hoist f (TaggedTrans t) = TaggedTrans (hoist f t)


### PR DESCRIPTION
If you try to build `ether-0.5.0.0` with `mmorph-1.1.0` (which made `MFunctor` poly-kinded) on GHC 8.0.1 or older, you'll get this inscrutable error message:

```
[1 of 8] Compiling Ether.Internal   ( src/Ether/Internal.hs, dist/build/Ether/Internal.o )
[2 of 8] Compiling Ether.TaggedTrans ( src/Ether/TaggedTrans.hs, dist/build/Ether/TaggedTrans.o )

src/Ether/TaggedTrans.hs:36:48: error:
    • No instance for (MFunctor trans)
        arising from the 'deriving' clause of a data type declaration
      Possible fix:
        use a standalone 'deriving instance' declaration,
          so you can specify the instance context yourself
    • When deriving the instance for (MMonad (TaggedTrans tag trans))
```

This is a result of [GHC Trac #11837](https://ghc.haskell.org/trac/ghc/ticket/11837), a bug which was fixed in GHC 8.0.2 (see https://github.com/Gabriel439/Haskell-MMorph-Library/issues/32). To work around this issue, I simply write out the `MFunctor` instance for `TaggedTrans` by hand.